### PR TITLE
Do not instrument components in node_modules

### DIFF
--- a/src/jsxTransform.js
+++ b/src/jsxTransform.js
@@ -32,7 +32,7 @@ function transform(filename, source, options) {
             filename: filename
         });
         result = jstransform.transform(visitors, source, opts);
-        var map = inlineSourceMap(result.sourceMap, source, filename);
+	const map = inlineSourceMap(result.sourceMap, source, filename);
         result.code = result.code + '\n' + map;
     } else {
         result = jstransform.transform(visitors, source, options);
@@ -50,8 +50,11 @@ function install(options) {
     if (!options.hasOwnProperty('sourceMapInline')) {
         options.sourceMapInline = true;
     }
+    if (!options.hasOwnProperty('extension')) {
+	options.extension = '.jsx';
+    }
 
-    require.extensions[options.extension || '.jsx'] = function loadJsx(module, filename) {
+    require.extensions[options.extension] = function loadJsx(module, filename) {
         var content = require('fs').readFileSync(filename, 'utf8');
         try {
             var instrumented = transform(filename, content, options);

--- a/src/transforms/custom-require-visitor.js
+++ b/src/transforms/custom-require-visitor.js
@@ -12,7 +12,9 @@ function requireVisitor(traverse, node, path, state) {
 
     const key = node.declarations[0].id.name;
     const requirePath = node.declarations[0].init.arguments[0].value;
-    globalUtils.addElementToGlobalMap(state, 'requireNodesMap', key, requirePath);
+    if (isOwnComponent(requirePath)) {
+	globalUtils.addElementToGlobalMap(state, 'requireNodesMap', key, requirePath);
+    }
 
     utils.catchup(node.range[1], state);
 }
@@ -27,5 +29,9 @@ requireVisitor.test = function (node, path, state) {
         node.declarations[0].init.callee.name === 'require'
     );
 };
+
+function isOwnComponent(requirePath) {
+    return requirePath.indexOf('.') === 0;
+}
 
 module.exports = requireVisitor;

--- a/test/fixtures/do_not_instrument_modules_input.jsx
+++ b/test/fixtures/do_not_instrument_modules_input.jsx
@@ -1,0 +1,8 @@
+const React = require('react');
+const OtherComponent = require('external-lib/OtherComponent');
+
+module.exports = class Component extends React.Component {
+    render() {
+	return <OtherComponent />
+    }
+};

--- a/test/fixtures/do_not_instrument_modules_result.jsx
+++ b/test/fixtures/do_not_instrument_modules_result.jsx
@@ -1,0 +1,9 @@
+var __electronHot__ = require('_electronHotLocation_');
+const React = require('react');
+const OtherComponent = require('external-lib/OtherComponent');
+
+module.exports = class Component extends React.Component {
+    render() {
+	return React.createElement(OtherComponent, null)
+    }
+};

--- a/test/spec/jsxTransform.spec.js
+++ b/test/spec/jsxTransform.spec.js
@@ -54,6 +54,14 @@ describe('jsxTransform', () => {
             './test/fixtures/higher_order_component_infile_result.jsx'
         )
     });
+
+    it('should not instrument components in node_modules', () => {
+	expectTransformation(
+	    {},
+	    './test/fixtures/do_not_instrument_modules_input.jsx',
+	    './test/fixtures/do_not_instrument_modules_result.jsx'
+	)
+    });
 });
 
 // When the token _ignore_ is found in the expected output,


### PR DESCRIPTION
There is now point in instrumenting components in node_modules.
We can check if the components belong to the user's project: the require imports start with a dot (i.e `./Component.jsx`)
