### PR TITLE
Add support for modules that export multiple components

### DIFF
--- a/src/proxies.js
+++ b/src/proxies.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 const createProxy = require('react-proxy/modules/index');
 
 const proxies = {};
@@ -7,25 +9,49 @@ let rootInstance;
 
 module.exports.register = register;
 module.exports.registerRoot = registerRoot;
-module.exports.getProxy = getProxy;
+module.exports.hasProxies = hasProxies;
+module.exports.updateProxies = updateProxies;
 module.exports.getRoot = getRoot;
+
+function traverseObject (object, path) {
+  if (path === '') return object;
+
+  const parts = path.split('.');
+  const member = parts[0];
+  const rest = parts.slice(1).join('.');
+  return traverseObject(object[member], rest);
+}
 
 function registerRoot (root) {
   rootInstance = root;
 }
 
-function register (Component, location) {
+function register (Component, location, path) {
+  assert(path !== undefined);
+
   const proxy = createProxy.default(Component);
 
   if (!proxies[location]) {
     console.debug('Registered proxy', location);
-    proxies[location] = proxy;
+    proxies[location] = {};
+    proxies[location][path] = proxy;
   }
-  return proxies[location].get();
+
+  return proxies[location][path].get();
 }
 
-function getProxy (location) {
-  return proxies[location];
+function hasProxies (location) {
+  return location in proxies;
+}
+
+function updateProxies (location, module) {
+  let moduleProxies = proxies[location];
+  for (let path in moduleProxies) {
+    let proxy = moduleProxies[path];
+
+    var newComponent = traverseObject(module, path);
+    proxy.update(newComponent);
+  }
 }
 
 function getRoot () {

--- a/src/transforms/higher-order-visitor.js
+++ b/src/transforms/higher-order-visitor.js
@@ -13,7 +13,7 @@ function higherOrderVisitor (traverse, node, path, state) {
     utils.catchup(component.arg.range[0], state);
     utils.append('__electronHot__.register(', state);
     utils.catchup(component.arg.range[1], state);
-    utils.append(', require.resolve(' + component.path.replace(/\\/g, '/') + '))', state);
+    utils.append(', require.resolve(' + component.path.replace(/\\/g, '/') + '), \'\')', state);
   });
 
   return false;

--- a/src/watchJsx.js
+++ b/src/watchJsx.js
@@ -7,8 +7,7 @@ const proxies = require('./proxies');
 module.exports = function watchJsx (directories, options) {
   const opts = Object.assign({}, options, {callbackArg: 'absolute'});
   watchGlob(directories, opts, f => {
-    const cachedProxy = proxies.getProxy(f);
-    if (cachedProxy) {
+    if (proxies.hasProxies(f)) {
       console.debug('Hot reload', f);
       const rootInstance = proxies.getRoot();
       if (!rootInstance) {
@@ -16,9 +15,12 @@ module.exports = function watchJsx (directories, options) {
           ' and that require("electron-hot-loader").install() has been called before any JSX is required.');
         return;
       }
+
       delete require.cache[f];
-      var newComponent = require(f);
-      cachedProxy.update(newComponent);
+      let module = require(f);
+
+      proxies.updateProxies(f, module);
+
       deepForceUpdate(rootInstance);
     }
   });

--- a/test/fixtures/higher_order_component_infile_result.jsx
+++ b/test/fixtures/higher_order_component_infile_result.jsx
@@ -8,4 +8,4 @@ class Component extends React.Component {
 
 module.exports = connect(
     (state) => ({counter: state.counter})
-)(__electronHot__.register(Component, require.resolve(__filename)));
+)(__electronHot__.register(Component, require.resolve(__filename), ''));

--- a/test/fixtures/higher_order_component_result.jsx
+++ b/test/fixtures/higher_order_component_result.jsx
@@ -5,4 +5,4 @@ const Component = require('./Component.jsx');
 
 module.exports = connect(
     (state) => ({counter: state.counter})
-)(__electronHot__.register(Component, require.resolve('./Component.jsx')));
+)(__electronHot__.register(Component, require.resolve('./Component.jsx'), ''));

--- a/test/fixtures/multiple_transform_and_instrument_input.jsx
+++ b/test/fixtures/multiple_transform_and_instrument_input.jsx
@@ -1,0 +1,14 @@
+const React = require('react');
+const multipleComponents = require('./multipleComponents.jsx');
+
+module.exports.ComponentA = class ComponentA extends React.Component {
+    render() {
+        return <multipleComponents.First />
+    }
+};
+
+module.exports.ComponentB = class ComponentB extends React.Component {
+    render() {
+        return <multipleComponents.Second />
+    }
+};

--- a/test/fixtures/multiple_transform_and_instrument_output.jsx
+++ b/test/fixtures/multiple_transform_and_instrument_output.jsx
@@ -1,0 +1,15 @@
+var __electronHot__ = require('_electronHotLocation_');
+const React = require('react');
+const multipleComponents = require('./multipleComponents.jsx');
+
+module.exports.ComponentA = class ComponentA extends React.Component {
+    render() {
+        return React.createElement(__electronHot__.register(multipleComponents.First, require.resolve('./multipleComponents.jsx'), 'First'), null)
+    }
+};
+
+module.exports.ComponentB = class ComponentB extends React.Component {
+    render() {
+        return React.createElement(__electronHot__.register(multipleComponents.Second, require.resolve('./multipleComponents.jsx'), 'Second'), null)
+    }
+};

--- a/test/fixtures/transform_and_instrument_result.jsx
+++ b/test/fixtures/transform_and_instrument_result.jsx
@@ -4,6 +4,6 @@ const OtherComponent = require('./OtherComponent.jsx');
 
 module.exports = class Component extends React.Component {
     render() {
-        return React.createElement(__electronHot__.register(OtherComponent, require.resolve('./OtherComponent.jsx')), null)
+        return React.createElement(__electronHot__.register(OtherComponent, require.resolve('./OtherComponent.jsx'), ''), null)
     }
 };

--- a/test/fixtures/transform_and_instrument_result_with_source_map.jsx
+++ b/test/fixtures/transform_and_instrument_result_with_source_map.jsx
@@ -4,7 +4,7 @@ const OtherComponent = require('./OtherComponent.jsx');
 
 module.exports = class Component extends React.Component {
     render() {
-        return React.createElement(__electronHot__.register(OtherComponent, require.resolve('./OtherComponent.jsx')), null)
+        return React.createElement(__electronHot__.register(OtherComponent, require.resolve('./OtherComponent.jsx'), ''), null)
     }
 };
 

--- a/test/fixtures/transform_and_instrument_top_level_result.jsx
+++ b/test/fixtures/transform_and_instrument_top_level_result.jsx
@@ -3,4 +3,4 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const App = require('./ui/App.jsx');
 
-__electronHot__.registerRoot(ReactDOM.render(React.createElement(__electronHot__.register(App, require.resolve('./ui/App.jsx')), null), document.getElementById('root')));
+__electronHot__.registerRoot(ReactDOM.render(React.createElement(__electronHot__.register(App, require.resolve('./ui/App.jsx'), ''), null), document.getElementById('root')));

--- a/test/spec/jsxTransform.spec.js
+++ b/test/spec/jsxTransform.spec.js
@@ -62,6 +62,14 @@ describe('jsxTransform', () => {
       './test/fixtures/do_not_instrument_modules_result.jsx'
     );
   });
+
+  it('should transform and instrument import with multiple components', () => {
+    expectTransformation(
+      {},
+      './test/fixtures/multiple_transform_and_instrument_input.jsx',
+      './test/fixtures/multiple_transform_and_instrument_output.jsx'
+    );
+  });
 });
 
 // When the token _ignore_ is found in the expected output,


### PR DESCRIPTION
Beyond that, it also supports the use case of exporting the component without assigning it to `module.exports`.

I ran into this problem when I was compiling typescript using the es6 module syntax, when you write

``` typescript
export default class Component...
...
import Component from './Component'`;
Component.foo();
```

it generates

``` javascript
exports.default = Component;
...
const component = require('./component');
component.default.foo();
```

This patch solves this issue by allowing the components to be exported to arbitrary member paths.

That it allows exporting multiple components from one module is just a bonus to me. 😄 
